### PR TITLE
Implement key configuration helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ _________________
 
 Working - you can enumerate devices, set the brightness of the panel(s), set
 the images shown on each button, and read the current button states.
+Hot-plug monitoring lets applications react to Stream Decks being connected or
+removed at runtime, and a simple macro framework is included for mapping
+button presses to custom actions. The ``MacroDeck`` helper also provides
+``configure_key()`` for quickly assigning images, labels and callbacks to keys.
 
 Currently the following StreamDeck products are supported in multiple hardware
 variants:

--- a/src/StreamDeck/DeviceMonitor.py
+++ b/src/StreamDeck/DeviceMonitor.py
@@ -1,0 +1,62 @@
+#         Python Stream Deck Library
+#      Released under the MIT license
+#
+#   dean [at] fourwalledcubicle [dot] com
+#         www.fourwalledcubicle.com
+#
+"""Hot-plug detection utilities for StreamDeck devices."""
+
+import threading
+import time
+from collections.abc import Callable
+
+from .DeviceManager import DeviceManager
+from .Devices.StreamDeck import StreamDeck
+
+
+class DeviceMonitor:
+    """Monitor StreamDeck connections and disconnections."""
+
+    def __init__(self, manager: DeviceManager, interval: float = 1.0):
+        self.manager = manager
+        self.interval = interval
+        self._running = False
+        self._thread: threading.Thread | None = None
+        self._known: dict[str, StreamDeck] = {}
+        self.on_connect: Callable[[StreamDeck], None] | None = None
+        self.on_disconnect: Callable[[StreamDeck], None] | None = None
+
+    def start(self, on_connect: Callable[[StreamDeck], None] | None = None,
+              on_disconnect: Callable[[StreamDeck], None] | None = None) -> None:
+        """Start monitoring for device changes."""
+        self.on_connect = on_connect
+        self.on_disconnect = on_disconnect
+        self._known = {d.id(): d for d in self.manager.enumerate()}
+        self._running = True
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        """Stop monitoring."""
+        self._running = False
+        if self._thread is not None:
+            self._thread.join()
+            self._thread = None
+
+    # Internal methods ---------------------------------------------------
+    def _run(self) -> None:
+        while self._running:
+            current = {d.id(): d for d in self.manager.enumerate()}
+
+            new_ids = set(current.keys()) - set(self._known.keys())
+            removed_ids = set(self._known.keys()) - set(current.keys())
+
+            for device_id in new_ids:
+                if self.on_connect:
+                    self.on_connect(current[device_id])
+            for device_id in removed_ids:
+                if self.on_disconnect:
+                    self.on_disconnect(self._known[device_id])
+
+            self._known = current
+            time.sleep(self.interval)

--- a/src/StreamDeck/MacroDeck.py
+++ b/src/StreamDeck/MacroDeck.py
@@ -1,0 +1,122 @@
+#         Python Stream Deck Library
+#      Released under the MIT license
+#
+#   dean [at] fourwalledcubicle [dot] com
+#         www.fourwalledcubicle.com
+#
+"""Simple macro framework for StreamDeck devices."""
+
+import subprocess
+from collections.abc import Callable
+from typing import Any
+from PIL import Image, ImageDraw, ImageFont
+
+from .ImageHelpers import PILHelper
+
+from .Devices.StreamDeck import StreamDeck, DialEventType, TouchscreenEventType
+
+
+class MacroDeck:
+    """High level wrapper to attach actions to deck events."""
+
+    def __init__(self, deck: StreamDeck):
+        self.deck = deck
+        self.key_macros: dict[int, Callable[[], Any] | str] = {}
+        self.dial_macros: dict[tuple[int, DialEventType], Callable[[Any], Any] | str] = {}
+        self.touch_macros: dict[TouchscreenEventType, Callable[[Any], Any] | str] = {}
+        self.key_configs: dict[int, dict[str, Any]] = {}
+
+        self.deck.set_key_callback(self._handle_key)
+        self.deck.set_dial_callback(self._handle_dial)
+        self.deck.set_touchscreen_callback(self._handle_touch)
+
+    def register_key_macro(self, key: int, action: Callable[[], Any] | str) -> None:
+        """Register a macro action for a key press."""
+        self.key_macros[key] = action
+
+    def register_dial_macro(self, dial: int, event: DialEventType, action: Callable[[Any], Any] | str) -> None:
+        """Register a macro action for a dial event."""
+        self.dial_macros[(dial, event)] = action
+
+    def register_touch_macro(self, event: TouchscreenEventType, action: Callable[[Any], Any] | str) -> None:
+        """Register a macro action for a touchscreen event."""
+        self.touch_macros[event] = action
+
+    def configure_key(
+        self,
+        key: int,
+        upimage: str | None = None,
+        downimage: str | None = None,
+        uptext: str | None = None,
+        downtext: str | None = None,
+        pressedcallback: Callable[[], Any] | str | None = None,
+    ) -> None:
+        """Configure images and callback for a key.
+
+        Any combination of parameters can be provided; omitted ones are
+        left unchanged.
+        """
+
+        config = self.key_configs.get(key, {"up_image": None, "down_image": None})
+
+        if upimage is not None or uptext is not None:
+            config["up_image"] = self._build_image(upimage, uptext)
+
+        if downimage is not None or downtext is not None:
+            config["down_image"] = self._build_image(downimage, downtext)
+
+        self.key_configs[key] = config
+
+        if pressedcallback is not None:
+            self.register_key_macro(key, pressedcallback)
+
+        if config.get("up_image") is not None:
+            self.deck.set_key_image(key, config["up_image"])
+
+    # Internal handlers ---------------------------------------------------
+    def _run_action(self, action: Callable | str, *args: Any) -> None:
+        if isinstance(action, str):
+            subprocess.Popen(action, shell=True)
+        else:
+            action(*args)
+
+    # Internal helpers ---------------------------------------------------
+    def _build_image(self, path: str | None, text: str | None) -> bytes | None:
+        if path is None and text is None:
+            return None
+
+        if path is not None:
+            image = Image.open(path).convert("RGBA")
+            image = PILHelper.create_scaled_key_image(self.deck, image)
+        else:
+            image = PILHelper.create_key_image(self.deck)
+
+        if text:
+            draw = ImageDraw.Draw(image)
+            font = ImageFont.load_default()
+            draw.text((image.width / 2, image.height / 2), text=text, anchor="mm", fill="white", font=font)
+
+        return PILHelper.to_native_key_format(self.deck, image)
+
+    def _handle_key(self, deck: StreamDeck, key: int, state: bool) -> None:
+        config = self.key_configs.get(key)
+        if config:
+            if state and config.get("down_image") is not None:
+                deck.set_key_image(key, config["down_image"])
+            elif not state and config.get("up_image") is not None:
+                deck.set_key_image(key, config["up_image"])
+
+        if state:
+            action = self.key_macros.get(key)
+            if action is not None:
+                self._run_action(action)
+
+    def _handle_dial(self, deck: StreamDeck, dial: int, event: DialEventType, value: Any) -> None:
+        action = self.dial_macros.get((dial, event))
+        if action is not None:
+            self._run_action(action, value)
+
+    def _handle_touch(self, deck: StreamDeck, event: TouchscreenEventType, data: Any) -> None:
+        action = self.touch_macros.get(event)
+        if action is not None:
+            self._run_action(action, data)

--- a/src/StreamDeck/__init__.py
+++ b/src/StreamDeck/__init__.py
@@ -1,0 +1,7 @@
+"""StreamDeck package."""
+
+from .DeviceManager import DeviceManager
+from .DeviceMonitor import DeviceMonitor
+from .MacroDeck import MacroDeck
+
+__all__ = ["DeviceManager", "DeviceMonitor", "MacroDeck"]


### PR DESCRIPTION
## Summary
- expand `MacroDeck` helper with `configure_key` for assigning images and callbacks
- mention new helper in README

## Testing
- `pip install -q -r requirements.txt`
- `python test/test.py --test "PIL Helpers" > /tmp/test.log && tail -n 5 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_6847fe0828b083278a93f3278bdfb33b