### PR TITLE
Add game helpers for MacroDeck

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ multiple macros together and refresh stored images on the device.
 ``run_loop()`` provides a simple game loop for deck-only games and ``set_key_text()`` displays text directly on a key.
 ``display_text()`` draws multi-line text across the deck while ``get_pressed_keys()``
 and ``wait_for_key_press()`` help reading user input for deck-only games.
+``position_to_key()`` and ``key_to_position()`` convert between key indexes and grid
+positions. ``display_board()`` renders a 2D array of characters, and
+``wait_for_char_press()`` returns the character associated with a pressed key.
 
 Currently the following StreamDeck products are supported in multiple hardware
 variants:

--- a/src/StreamDeck/MacroDeck.py
+++ b/src/StreamDeck/MacroDeck.py
@@ -371,6 +371,36 @@ class MacroDeck:
                 char = line[col] if col < len(line) else ""
                 self.set_key_text(key, char)
 
+    def position_to_key(self, row: int, col: int) -> int:
+        """Return the key index for a given ``(row, column)`` position."""
+        if not (0 <= row < self.deck.KEY_ROWS) or not (0 <= col < self.deck.KEY_COLS):
+            raise IndexError("Invalid row or column")
+        return row * self.deck.KEY_COLS + col
+
+    def key_to_position(self, key: int) -> tuple[int, int]:
+        """Return the ``(row, column)`` position for a key index."""
+        if not (0 <= key < self.deck.key_count()):
+            raise IndexError("Invalid key index")
+        return divmod(key, self.deck.KEY_COLS)
+
+    def display_board(self, board: list[list[str]]) -> None:
+        """Display a 2D array of single characters across the deck."""
+        for row in range(self.deck.KEY_ROWS):
+            for col in range(self.deck.KEY_COLS):
+                char = ""
+                if row < len(board) and col < len(board[row]):
+                    char = board[row][col]
+                self.set_key_text(self.position_to_key(row, col), char)
+
+    def wait_for_char_press(
+        self, char_map: dict[int, str], timeout: float | None = None
+    ) -> str | None:
+        """Wait for a key press and return the mapped character or ``None``."""
+        key = self.wait_for_key_press(timeout)
+        if key is None:
+            return None
+        return char_map.get(key)
+
     def run_loop(
         self,
         frame_callback: Callable[["MacroDeck", float], bool] | None = None,

--- a/test/test.py
+++ b/test/test.py
@@ -157,6 +157,25 @@ def test_display_text_and_wait(deck):
     assert pressed is None
 
 
+def test_game_helpers(deck):
+    if not deck.is_visual():
+        return
+
+    mdeck = MacroDeck(deck)
+    board = [["X" for _ in range(deck.KEY_COLS)] for _ in range(deck.KEY_ROWS)]
+
+    with deck:
+        deck.open()
+        mdeck.display_board(board)
+        pos = mdeck.key_to_position(0)
+        idx = mdeck.position_to_key(*pos)
+        char = mdeck.wait_for_char_press({0: "A"}, timeout=0)
+        deck.close()
+
+    assert idx == 0
+    assert char is None
+
+
 if __name__ == "__main__":
     logging.basicConfig(level=logging.ERROR)
 
@@ -184,6 +203,7 @@ if __name__ == "__main__":
         "Run Loop": test_run_loop,
         "Set Key Text": test_set_key_text,
         "Display Text": test_display_text_and_wait,
+        "Game Helpers": test_game_helpers,
     }
 
     test_runners = tests


### PR DESCRIPTION
## Summary
- add helpers to `MacroDeck` for position math, board display and char input
- document new helpers in `README`
- test new helpers in `test.py`

## Testing
- `python test/test.py && echo OK`

------
https://chatgpt.com/codex/tasks/task_e_687d0a2bad908327b7b55940557efcb0