### PR TITLE
Add game board helpers

### DIFF
--- a/src/StreamDeck/MacroDeck.py
+++ b/src/StreamDeck/MacroDeck.py
@@ -438,6 +438,32 @@ class MacroDeck:
         if self.board is not None:
             self.display_board(self.board)
 
+    def draw_text(self, row: int, col: int, text: str) -> None:
+        """Draw ``text`` onto the internal board starting at ``(row, col)``."""
+        if self.board is None:
+            self.create_board()
+        for offset, char in enumerate(text):
+            r = row
+            c = col + offset
+            if 0 <= r < self.deck.KEY_ROWS and 0 <= c < self.deck.KEY_COLS:
+                self.board[r][c] = char
+                self.set_key_text(self.position_to_key(r, c), char)
+
+    def overlay_board(
+        self, board: list[list[str]], top: int = 0, left: int = 0
+    ) -> None:
+        """Overlay ``board`` onto the internal board at ``(top, left)``."""
+        if self.board is None:
+            self.create_board()
+
+        for r, row_data in enumerate(board):
+            for c, char in enumerate(row_data):
+                rr = top + r
+                cc = left + c
+                if 0 <= rr < self.deck.KEY_ROWS and 0 <= cc < self.deck.KEY_COLS:
+                    self.board[rr][cc] = char
+                    self.set_key_text(self.position_to_key(rr, cc), char)
+
     def wait_for_char_press(
         self, char_map: dict[int, str], timeout: float | None = None
     ) -> str | None:

--- a/test/test.py
+++ b/test/test.py
@@ -167,6 +167,8 @@ def test_game_helpers(deck):
     with deck:
         deck.open()
         mdeck.display_board(board)
+        mdeck.draw_text(0, 0, "HI")
+        mdeck.overlay_board([["Z"]], top=1, left=1)
         pos = mdeck.key_to_position(0)
         idx = mdeck.position_to_key(*pos)
         char = mdeck.wait_for_char_press({0: "A"}, timeout=0)


### PR DESCRIPTION
## Summary
- add `draw_text` and `overlay_board` helpers to `MacroDeck`
- exercise new helpers in tests

## Testing
- `python test/test.py --model "Stream Deck Mini" --test "Game Helpers"`
- `python test/test.py --model "Stream Deck Mini" --test "Board State"`

------
https://chatgpt.com/codex/tasks/task_e_687d0ed842248327aaa7fef2fab3d8f3