### PR TITLE
Add board manipulation helpers for deck-only games

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ positions. ``display_board()`` renders a 2D array of characters, and
 ``wait_for_char_press()`` returns the character associated with a pressed key.
 ``create_board()`` and related helpers manage a persistent character grid for
 deck-only games, allowing individual cells to be updated and redrawn easily.
+``scroll_board()``, ``draw_rect()`` and ``fill_rect()`` provide additional
+helpers for moving and drawing on the board.
 
 Currently the following StreamDeck products are supported in multiple hardware
 variants:

--- a/src/StreamDeck/MacroDeck.py
+++ b/src/StreamDeck/MacroDeck.py
@@ -464,6 +464,53 @@ class MacroDeck:
                     self.board[rr][cc] = char
                     self.set_key_text(self.position_to_key(rr, cc), char)
 
+    def scroll_board(self, dx: int = 0, dy: int = 0, fill: str = " ") -> None:
+        """Scroll the board by ``(dx, dy)`` and fill empty cells with ``fill``."""
+        if self.board is None:
+            self.create_board(fill)
+
+        new_board = [[fill for _ in range(self.deck.KEY_COLS)] for _ in range(self.deck.KEY_ROWS)]
+
+        for r in range(self.deck.KEY_ROWS):
+            for c in range(self.deck.KEY_COLS):
+                nr = r + dy
+                nc = c + dx
+                if 0 <= nr < self.deck.KEY_ROWS and 0 <= nc < self.deck.KEY_COLS:
+                    new_board[nr][nc] = self.board[r][c]
+
+        self.board = new_board
+        self.refresh_board()
+
+    def draw_rect(self, top: int, left: int, height: int, width: int, char: str) -> None:
+        """Draw a rectangle on the board using ``char``."""
+        if self.board is None:
+            self.create_board()
+
+        for r in range(top, top + height):
+            if 0 <= r < self.deck.KEY_ROWS:
+                if 0 <= left < self.deck.KEY_COLS:
+                    self.set_board_char(r, left, char)
+                if 0 <= left + width - 1 < self.deck.KEY_COLS:
+                    self.set_board_char(r, left + width - 1, char)
+
+        for c in range(left, left + width):
+            if 0 <= c < self.deck.KEY_COLS:
+                if 0 <= top < self.deck.KEY_ROWS:
+                    self.set_board_char(top, c, char)
+                if 0 <= top + height - 1 < self.deck.KEY_ROWS:
+                    self.set_board_char(top + height - 1, c, char)
+
+    def fill_rect(self, top: int, left: int, height: int, width: int, char: str) -> None:
+        """Fill a rectangular region on the board with ``char``."""
+        if self.board is None:
+            self.create_board()
+
+        for r in range(top, top + height):
+            if 0 <= r < self.deck.KEY_ROWS:
+                for c in range(left, left + width):
+                    if 0 <= c < self.deck.KEY_COLS:
+                        self.set_board_char(r, c, char)
+
     def wait_for_char_press(
         self, char_map: dict[int, str], timeout: float | None = None
     ) -> str | None:

--- a/test/test.py
+++ b/test/test.py
@@ -196,6 +196,22 @@ def test_board_state(deck):
     assert board[0][0] == "A"
 
 
+def test_board_draw_scroll(deck):
+    if not deck.is_visual():
+        return
+
+    mdeck = MacroDeck(deck)
+    with deck:
+        deck.open()
+        mdeck.create_board()
+        mdeck.fill_rect(0, 0, 2, 2, "A")
+        mdeck.draw_rect(0, 0, 2, 2, "B")
+        mdeck.scroll_board(1, 1)
+        deck.close()
+
+    assert mdeck.get_board_char(1, 1) == "B"
+
+
 if __name__ == "__main__":
     logging.basicConfig(level=logging.ERROR)
 
@@ -225,6 +241,7 @@ if __name__ == "__main__":
         "Display Text": test_display_text_and_wait,
         "Game Helpers": test_game_helpers,
         "Board State": test_board_state,
+        "Board Draw": test_board_draw_scroll,
     }
 
     test_runners = tests


### PR DESCRIPTION
## Summary
- extend `MacroDeck` with `scroll_board`, `draw_rect` and `fill_rect`
- document new helpers in README
- add tests for new features

## Testing
- `python3 -m py_compile src/StreamDeck/MacroDeck.py test/test.py`
- `python3 test/test.py`

------
https://chatgpt.com/codex/tasks/task_e_687d17342e3c8327a1a0450327fc681a