### PR TITLE
Add draw_line game helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ positions. ``display_board()`` renders a 2D array of characters, and
 ``wait_for_char_press()`` returns the character associated with a pressed key.
 ``create_board()`` and related helpers manage a persistent character grid for
 deck-only games, allowing individual cells to be updated and redrawn easily.
-``scroll_board()``, ``draw_rect()`` and ``fill_rect()`` provide additional
+``scroll_board()``, ``draw_line()``, ``draw_rect()`` and ``fill_rect()`` provide additional
 helpers for moving and drawing on the board.
 
 Currently the following StreamDeck products are supported in multiple hardware

--- a/src/StreamDeck/MacroDeck.py
+++ b/src/StreamDeck/MacroDeck.py
@@ -511,6 +511,32 @@ class MacroDeck:
                     if 0 <= c < self.deck.KEY_COLS:
                         self.set_board_char(r, c, char)
 
+    def draw_line(
+        self,
+        start_row: int,
+        start_col: int,
+        end_row: int,
+        end_col: int,
+        char: str,
+    ) -> None:
+        """Draw a straight line on the board using ``char``."""
+        if self.board is None:
+            self.create_board()
+
+        dr = end_row - start_row
+        dc = end_col - start_col
+        steps = max(abs(dr), abs(dc))
+        if steps == 0:
+            if 0 <= start_row < self.deck.KEY_ROWS and 0 <= start_col < self.deck.KEY_COLS:
+                self.set_board_char(start_row, start_col, char)
+            return
+
+        for i in range(steps + 1):
+            r = round(start_row + (dr * i) / steps)
+            c = round(start_col + (dc * i) / steps)
+            if 0 <= r < self.deck.KEY_ROWS and 0 <= c < self.deck.KEY_COLS:
+                self.set_board_char(r, c, char)
+
     def wait_for_char_press(
         self, char_map: dict[int, str], timeout: float | None = None
     ) -> str | None:

--- a/test/test.py
+++ b/test/test.py
@@ -212,6 +212,20 @@ def test_board_draw_scroll(deck):
     assert mdeck.get_board_char(1, 1) == "B"
 
 
+def test_draw_line(deck):
+    if not deck.is_visual():
+        return
+
+    mdeck = MacroDeck(deck)
+    with deck:
+        deck.open()
+        mdeck.create_board()
+        mdeck.draw_line(0, 0, deck.KEY_ROWS - 1, deck.KEY_COLS - 1, "C")
+        deck.close()
+
+    assert mdeck.get_board_char(deck.KEY_ROWS - 1, deck.KEY_COLS - 1) == "C"
+
+
 if __name__ == "__main__":
     logging.basicConfig(level=logging.ERROR)
 
@@ -242,6 +256,7 @@ if __name__ == "__main__":
         "Game Helpers": test_game_helpers,
         "Board State": test_board_state,
         "Board Draw": test_board_draw_scroll,
+        "Draw Line": test_draw_line,
     }
 
     test_runners = tests


### PR DESCRIPTION
## Summary
- add `draw_line` helper to `MacroDeck`
- update README to mention new helper
- test the new helper

## Testing
- `python test/test.py --test "Draw Line"`

------
https://chatgpt.com/codex/tasks/task_e_687d189a8bd883279f877a19c6b5b43d