### PR TITLE
Add board string helpers for deck-only games

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -34,6 +34,10 @@ Version 0.9.16:
         - Added ``display_text()`` helper for multi-line text output.
         - Added ``get_pressed_keys()`` and ``wait_for_key_press()`` input helpers.
 
+Version 0.9.17:
+        - Added ``create_board_from_strings()``, ``get_board_as_strings()`` and
+          ``draw_multiline_text()`` helpers for deck-only games.
+
 Version 0.9.7:
         - Added type hints to public APIs.
         - Fixed leading whitespace in StreamDeck Plus serial number strings.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ positions. ``display_board()`` renders a 2D array of characters, and
 ``create_board()`` and related helpers manage a persistent character grid for
 deck-only games, allowing individual cells to be updated and redrawn easily.
 ``scroll_board()``, ``draw_line()``, ``draw_rect()`` and ``fill_rect()`` provide additional
-helpers for moving and drawing on the board.
+helpers for moving and drawing on the board. ``create_board_from_strings()`` quickly
+populates a board from lines of text, ``get_board_as_strings()`` returns the board
+as text and ``draw_multiline_text()`` overlays several lines at once.
 
 Currently the following StreamDeck products are supported in multiple hardware
 variants:

--- a/src/StreamDeck/MacroDeck.py
+++ b/src/StreamDeck/MacroDeck.py
@@ -400,6 +400,17 @@ class MacroDeck:
         self.board = [[fill for _ in range(self.deck.KEY_COLS)] for _ in range(self.deck.KEY_ROWS)]
         self.display_board(self.board)
 
+    def create_board_from_strings(self, lines: list[str], fill: str = " ") -> None:
+        """Create an internal board from ``lines`` and display it."""
+        rows = self.deck.KEY_ROWS
+        cols = self.deck.KEY_COLS
+        self.board = [[fill for _ in range(cols)] for _ in range(rows)]
+        for r in range(min(rows, len(lines))):
+            line = lines[r]
+            for c in range(min(cols, len(line))):
+                self.board[r][c] = line[c]
+        self.display_board(self.board)
+
     def clear_board(self, fill: str = " ") -> None:
         """Clear the internal board to ``fill`` and redraw it."""
         if self.board is None:
@@ -433,6 +444,12 @@ class MacroDeck:
             raise ValueError("Board not initialised")
         return [list(r) for r in self.board]
 
+    def get_board_as_strings(self) -> list[str]:
+        """Return the internal board as a list of strings."""
+        if self.board is None:
+            raise ValueError("Board not initialised")
+        return ["".join(row) for row in self.board]
+
     def refresh_board(self) -> None:
         """Redraw the internal board on the deck."""
         if self.board is not None:
@@ -448,6 +465,18 @@ class MacroDeck:
             if 0 <= r < self.deck.KEY_ROWS and 0 <= c < self.deck.KEY_COLS:
                 self.board[r][c] = char
                 self.set_key_text(self.position_to_key(r, c), char)
+
+    def draw_multiline_text(self, top: int, left: int, lines: list[str]) -> None:
+        """Draw multiple lines of text onto the board starting at ``(top, left)``."""
+        if self.board is None:
+            self.create_board()
+        for r, line in enumerate(lines):
+            for c, char in enumerate(line):
+                rr = top + r
+                cc = left + c
+                if 0 <= rr < self.deck.KEY_ROWS and 0 <= cc < self.deck.KEY_COLS:
+                    self.board[rr][cc] = char
+                    self.set_key_text(self.position_to_key(rr, cc), char)
 
     def overlay_board(
         self, board: list[list[str]], top: int = 0, left: int = 0

--- a/test/test.py
+++ b/test/test.py
@@ -226,6 +226,22 @@ def test_draw_line(deck):
     assert mdeck.get_board_char(deck.KEY_ROWS - 1, deck.KEY_COLS - 1) == "C"
 
 
+def test_board_string_helpers(deck):
+    if not deck.is_visual():
+        return
+
+    mdeck = MacroDeck(deck)
+    with deck:
+        deck.open()
+        mdeck.create_board_from_strings(["AB", "CD"])
+        lines = mdeck.get_board_as_strings()
+        mdeck.draw_multiline_text(0, 0, ["XY", "Z"])
+        deck.close()
+
+    assert lines[0].startswith("AB")
+    assert mdeck.get_board_char(1, 0) == "Z"
+
+
 if __name__ == "__main__":
     logging.basicConfig(level=logging.ERROR)
 
@@ -257,6 +273,7 @@ if __name__ == "__main__":
         "Board State": test_board_state,
         "Board Draw": test_board_draw_scroll,
         "Draw Line": test_draw_line,
+        "Board Strings": test_board_string_helpers,
     }
 
     test_runners = tests


### PR DESCRIPTION
## Summary
- expand MacroDeck board helpers with create_board_from_strings, get_board_as_strings and draw_multiline_text
- document the new helpers and update changelog
- add tests covering the new helpers

## Testing
- `python test/test.py`


------
https://chatgpt.com/codex/tasks/task_e_687d1ab455b4832782b7955ec29c0ef8