### PR TITLE
Add board input helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ and ``wait_for_key_press()`` help reading user input for deck-only games.
 ``position_to_key()`` and ``key_to_position()`` convert between key indexes and grid
 positions. ``display_board()`` renders a 2D array of characters, and
 ``wait_for_char_press()`` returns the character associated with a pressed key.
+``get_pressed_chars()`` lists the characters on pressed keys and
+``wait_for_board_press()`` returns the character displayed on the next key press.
 ``create_board()`` and related helpers manage a persistent character grid for
 deck-only games, allowing individual cells to be updated and redrawn easily.
 ``scroll_board()``, ``draw_line()``, ``draw_rect()`` and ``fill_rect()`` provide additional

--- a/src/StreamDeck/MacroDeck.py
+++ b/src/StreamDeck/MacroDeck.py
@@ -351,6 +351,17 @@ class MacroDeck:
         """Return a list of keys that are currently pressed."""
         return [i for i, state in enumerate(self.deck.key_states()) if state]
 
+    def get_pressed_chars(self) -> list[str]:
+        """Return the characters on all currently pressed keys."""
+        if self.board is None:
+            raise ValueError("Board not initialised")
+
+        chars: list[str] = []
+        for key in self.get_pressed_keys():
+            row, col = self.key_to_position(key)
+            chars.append(self.board[row][col])
+        return chars
+
     def wait_for_key_press(self, timeout: float | None = None) -> int | None:
         """Wait for a key press and return its index or ``None`` on timeout."""
         start = time.time()
@@ -574,6 +585,18 @@ class MacroDeck:
         if key is None:
             return None
         return char_map.get(key)
+
+    def wait_for_board_press(self, timeout: float | None = None) -> str | None:
+        """Wait for a key press and return the character shown on the key."""
+        if self.board is None:
+            raise ValueError("Board not initialised")
+
+        char_map: dict[int, str] = {}
+        for r, row in enumerate(self.board):
+            for c, char in enumerate(row):
+                char_map[self.position_to_key(r, c)] = char
+
+        return self.wait_for_char_press(char_map, timeout)
 
     def run_loop(
         self,


### PR DESCRIPTION
## Summary
- expose pressed characters
- map key presses directly to board characters

## Testing
- `python -m py_compile src/StreamDeck/MacroDeck.py`

------
https://chatgpt.com/codex/tasks/task_e_687d2516ec0083278263260fcd1a8b4a