### PR TITLE
Add image board helpers for StreamDeck games

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ deck-only games, allowing individual cells to be updated and redrawn easily.
 helpers for moving and drawing on the board. ``create_board_from_strings()`` quickly
 populates a board from lines of text, ``get_board_as_strings()`` returns the board
 as text and ``draw_multiline_text()`` overlays several lines at once.
+``create_image_board()`` and related helpers manage a board of key images for
+deck-only games, allowing graphics to be scrolled or overlaid easily.
 
 Currently the following StreamDeck products are supported in multiple hardware
 variants:

--- a/test/test.py
+++ b/test/test.py
@@ -242,6 +242,26 @@ def test_board_string_helpers(deck):
     assert mdeck.get_board_char(1, 0) == "Z"
 
 
+def test_image_board(deck):
+    if not deck.is_visual():
+        return
+
+    mdeck = MacroDeck(deck)
+    img = PILHelper.to_native_key_format(deck, PILHelper.create_key_image(deck))
+    board = [[img for _ in range(deck.KEY_COLS)] for _ in range(deck.KEY_ROWS)]
+
+    with deck:
+        deck.open()
+        mdeck.create_image_board()
+        mdeck.set_board_image(0, 0, img)
+        stored = mdeck.get_board_image(0, 0)
+        mdeck.display_image_board(board)
+        mdeck.scroll_image_board(1, 0)
+        deck.close()
+
+    assert stored == img
+
+
 if __name__ == "__main__":
     logging.basicConfig(level=logging.ERROR)
 
@@ -274,6 +294,7 @@ if __name__ == "__main__":
         "Board Draw": test_board_draw_scroll,
         "Draw Line": test_draw_line,
         "Board Strings": test_board_string_helpers,
+        "Image Board": test_image_board,
     }
 
     test_runners = tests


### PR DESCRIPTION
## Summary
- add `image_board` support to `MacroDeck` for deck-only games
- document new helpers in README
- test image board behavior

## Testing
- `pip install -q -r requirements.txt`
- `flake8`
- `python3 -m pytest -q` *(no tests discovered)*

------
https://chatgpt.com/codex/tasks/task_e_687d2bdce9548327851b2571ad9c9ce4