### PR TITLE
Add display_deck_image helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ populates a board from lines of text, ``get_board_as_strings()`` returns the boa
 as text and ``draw_multiline_text()`` overlays several lines at once.
 ``create_image_board()`` and related helpers manage a board of key images for
 deck-only games, allowing graphics to be scrolled or overlaid easily.
+``display_deck_image()`` scales a single image across the entire deck and updates the
+internal image board for further manipulation.
 
 Currently the following StreamDeck products are supported in multiple hardware
 variants:

--- a/src/StreamDeck/MacroDeck.py
+++ b/src/StreamDeck/MacroDeck.py
@@ -673,6 +673,43 @@ class MacroDeck:
         self.image_board = new_board
         self.refresh_image_board()
 
+    def display_deck_image(
+        self, image: Image.Image, key_spacing: tuple[int, int] = (0, 0)
+    ) -> None:
+        """Display ``image`` scaled across the entire deck surface.
+
+        The image will be automatically resized to fit the deck and then
+        split into per-key tiles before being sent to the device. The
+        ``image_board`` state is updated so that the displayed graphics can be
+        further manipulated with the other image board helpers.
+
+        Parameters
+        ----------
+        image
+            Source PIL image to display.
+        key_spacing
+            Horizontal and vertical pixel spacing between keys, used when
+            computing the deck surface size.
+        """
+
+        if not self.deck.is_visual():
+            return
+
+        deck_img = PILHelper.create_deck_sized_image(self.deck, image, key_spacing)
+        tiles = PILHelper.split_deck_image(self.deck, deck_img, key_spacing)
+
+        board: list[list[bytes | None]] = []
+        for r in range(self.deck.KEY_ROWS):
+            row_imgs: list[bytes | None] = []
+            for c in range(self.deck.KEY_COLS):
+                key = self.position_to_key(r, c)
+                tile = tiles[key]
+                self.deck.set_key_image(key, tile)
+                row_imgs.append(tile)
+            board.append(row_imgs)
+
+        self.image_board = board
+
     def wait_for_char_press(
         self, char_map: dict[int, str], timeout: float | None = None
     ) -> str | None:

--- a/test/test.py
+++ b/test/test.py
@@ -274,6 +274,22 @@ def test_deck_image_helpers(deck):
     assert isinstance(next(iter(tiles.values())), bytes)
 
 
+def test_display_deck_image(deck):
+    if not deck.is_visual():
+        return
+
+    mdeck = MacroDeck(deck)
+    img = PILHelper.create_key_image(deck)
+    deck_img = PILHelper.create_deck_sized_image(deck, img)
+
+    with deck:
+        deck.open()
+        mdeck.display_deck_image(deck_img)
+        deck.close()
+
+    assert mdeck.image_board is not None
+
+
 if __name__ == "__main__":
     logging.basicConfig(level=logging.ERROR)
 
@@ -308,6 +324,7 @@ if __name__ == "__main__":
         "Board Strings": test_board_string_helpers,
         "Image Board": test_image_board,
         "Deck Image Helpers": test_deck_image_helpers,
+        "Display Deck Image": test_display_deck_image,
     }
 
     test_runners = tests


### PR DESCRIPTION
## Summary
- add MacroDeck.display_deck_image for deck-sized images
- document helper in README
- test displaying deck-sized images

## Testing
- `python test/test.py --test "Deck Image Helpers"`
- `flake8`
- `bandit -r src`

------
https://chatgpt.com/codex/tasks/task_e_687d328630e483279d4a1c506810bf93