### PR TITLE
Add single key image helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ re-enabled with ``disable()`` and ``enable()``.
 Bulk helpers can configure or clear several keys at once, register
 multiple macros together and refresh stored images on the device.
 ``run_loop()`` provides a simple game loop for deck-only games and ``set_key_text()`` displays text directly on a key.
+``set_key_image_file()`` and ``set_key_image_pil()`` simplify showing images on individual keys.
 ``display_text()`` draws multi-line text across the deck while ``get_pressed_keys()``
 and ``wait_for_key_press()`` help reading user input for deck-only games.
 ``position_to_key()`` and ``key_to_position()`` convert between key indexes and grid

--- a/src/StreamDeck/MacroDeck.py
+++ b/src/StreamDeck/MacroDeck.py
@@ -348,6 +348,25 @@ class MacroDeck:
         else:
             self.update_key_configuration(key, uptext=text)
 
+    def set_key_image_file(self, key: int, path: str, pressed: bool = False) -> None:
+        """Display an image from ``path`` on a key."""
+        if pressed:
+            self.update_key_configuration(key, downimage=path)
+        else:
+            self.update_key_configuration(key, upimage=path)
+
+    def set_key_image_pil(self, key: int, image: Image.Image, pressed: bool = False) -> None:
+        """Display a PIL image on a key."""
+        img = PILHelper.to_native_key_format(self.deck, PILHelper.create_scaled_key_image(self.deck, image))
+        config = self.key_configs.get(key, {"up_image": None, "down_image": None})
+        if pressed:
+            config["down_image"] = img
+        else:
+            config["up_image"] = img
+        self.key_configs[key] = config
+        if self.deck.is_visual():
+            self.deck.set_key_image(key, img)
+
     def get_pressed_keys(self) -> list[int]:
         """Return a list of keys that are currently pressed."""
         return [i for i, state in enumerate(self.deck.key_states()) if state]


### PR DESCRIPTION
## Summary
- support quick single-key image updates
- document new functions in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `python test/test.py`

------
https://chatgpt.com/codex/tasks/task_e_687d343ec34c83278cd8f838f9ee1828