### PR TITLE
Add single key image helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ re-enabled with ``disable()`` and ``enable()``.
 Bulk helpers can configure or clear several keys at once, register
 multiple macros together and refresh stored images on the device.
 ``run_loop()`` provides a simple game loop for deck-only games and ``set_key_text()`` displays text directly on a key.
-``set_key_image_file()`` and ``set_key_image_pil()`` simplify showing images on individual keys.
+``set_key_image_file()`` and ``set_key_image_pil()`` simplify showing images on individual keys. ``set_key_image_bytes()`` accepts pre-formatted images and ``get_key_image()``, ``has_key_image()`` and ``clear_key_image()`` help manage stored key images.
 ``display_text()`` draws multi-line text across the deck while ``get_pressed_keys()``
 and ``wait_for_key_press()`` help reading user input for deck-only games.
 ``position_to_key()`` and ``key_to_position()`` convert between key indexes and grid

--- a/src/StreamDeck/MacroDeck.py
+++ b/src/StreamDeck/MacroDeck.py
@@ -367,6 +367,40 @@ class MacroDeck:
         if self.deck.is_visual():
             self.deck.set_key_image(key, img)
 
+    def set_key_image_bytes(self, key: int, image: bytes | None, pressed: bool = False) -> None:
+        """Display a pre-formatted image on a key."""
+        config = self.key_configs.get(key, {"up_image": None, "down_image": None})
+        if pressed:
+            config["down_image"] = image
+        else:
+            config["up_image"] = image
+        self.key_configs[key] = config
+        if self.deck.is_visual():
+            self.deck.set_key_image(key, image)
+
+    def get_key_image(self, key: int, pressed: bool = False) -> bytes | None:
+        """Return the stored image for ``key`` if present."""
+        config = self.key_configs.get(key)
+        if config is None:
+            return None
+        return config.get("down_image" if pressed else "up_image")
+
+    def has_key_image(self, key: int, pressed: bool = False) -> bool:
+        """Return ``True`` if ``key`` has an image stored."""
+        return self.get_key_image(key, pressed) is not None
+
+    def clear_key_image(self, key: int, pressed: bool | None = None) -> None:
+        """Remove stored images from ``key`` without altering its macro."""
+        config = self.key_configs.get(key)
+        if config is None:
+            return
+        if pressed is None or not pressed:
+            config["up_image"] = None
+        if pressed is None or pressed:
+            config["down_image"] = None
+        if self.deck.is_visual():
+            self.deck.set_key_image(key, None)
+
     def get_pressed_keys(self) -> list[int]:
         """Return a list of keys that are currently pressed."""
         return [i for i, state in enumerate(self.deck.key_states()) if state]

--- a/test/test.py
+++ b/test/test.py
@@ -290,6 +290,26 @@ def test_display_deck_image(deck):
     assert mdeck.image_board is not None
 
 
+def test_key_image_helpers(deck):
+    if not deck.is_visual():
+        return
+
+    mdeck = MacroDeck(deck)
+    img = PILHelper.to_native_key_format(deck, PILHelper.create_key_image(deck))
+
+    with deck:
+        deck.open()
+        mdeck.set_key_image_bytes(0, img)
+        stored = mdeck.get_key_image(0)
+        has = mdeck.has_key_image(0)
+        mdeck.clear_key_image(0)
+        deck.close()
+
+    assert stored == img
+    assert has
+    assert mdeck.get_key_image(0) is None
+
+
 if __name__ == "__main__":
     logging.basicConfig(level=logging.ERROR)
 
@@ -325,6 +345,7 @@ if __name__ == "__main__":
         "Image Board": test_image_board,
         "Deck Image Helpers": test_deck_image_helpers,
         "Display Deck Image": test_display_deck_image,
+        "Key Image Helpers": test_key_image_helpers,
     }
 
     test_runners = tests


### PR DESCRIPTION
## Summary
- add helpers for handling raw key images
- document new functions in README
- test single key image helpers

## Testing
- `python test/test.py --test "Key Image Helpers"`
- `python test/test.py`

------
https://chatgpt.com/codex/tasks/task_e_687d37d7bc5883278c2c291c5029fd93