### PR TITLE
Add key image movement helpers

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -38,6 +38,10 @@ Version 0.9.17:
         - Added ``create_board_from_strings()``, ``get_board_as_strings()`` and
           ``draw_multiline_text()`` helpers for deck-only games.
 
+Version 0.9.18:
+        - Added ``copy_key_image()``, ``move_key_image()`` and
+          ``swap_key_images()`` helpers for single key image management.
+
 Version 0.9.7:
         - Added type hints to public APIs.
         - Fixed leading whitespace in StreamDeck Plus serial number strings.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ re-enabled with ``disable()`` and ``enable()``.
 Bulk helpers can configure or clear several keys at once, register
 multiple macros together and refresh stored images on the device.
 ``run_loop()`` provides a simple game loop for deck-only games and ``set_key_text()`` displays text directly on a key.
-``set_key_image_file()`` and ``set_key_image_pil()`` simplify showing images on individual keys. ``set_key_image_bytes()`` accepts pre-formatted images and ``get_key_image()``, ``has_key_image()`` and ``clear_key_image()`` help manage stored key images.
+``set_key_image_file()`` and ``set_key_image_pil()`` simplify showing images on individual keys. ``set_key_image_bytes()`` accepts pre-formatted images and ``get_key_image()``, ``has_key_image()``, ``clear_key_image()``, ``copy_key_image()``, ``move_key_image()`` and ``swap_key_images()`` help manage stored key images.
 ``display_text()`` draws multi-line text across the deck while ``get_pressed_keys()``
 and ``wait_for_key_press()`` help reading user input for deck-only games.
 ``position_to_key()`` and ``key_to_position()`` convert between key indexes and grid

--- a/src/StreamDeck/MacroDeck.py
+++ b/src/StreamDeck/MacroDeck.py
@@ -401,6 +401,29 @@ class MacroDeck:
         if self.deck.is_visual():
             self.deck.set_key_image(key, None)
 
+    def copy_key_image(self, source: int, destination: int, pressed: bool = False) -> None:
+        """Copy the image from ``source`` key to ``destination`` key."""
+        if source == destination:
+            return
+
+        img = self.get_key_image(source, pressed)
+        self.set_key_image_bytes(destination, img, pressed)
+
+    def move_key_image(self, source: int, destination: int, pressed: bool = False) -> None:
+        """Move the image from ``source`` key to ``destination`` key."""
+        self.copy_key_image(source, destination, pressed)
+        self.clear_key_image(source, pressed)
+
+    def swap_key_images(self, key_a: int, key_b: int, pressed: bool = False) -> None:
+        """Swap the images of ``key_a`` and ``key_b``."""
+        if key_a == key_b:
+            return
+
+        img_a = self.get_key_image(key_a, pressed)
+        img_b = self.get_key_image(key_b, pressed)
+        self.set_key_image_bytes(key_a, img_b, pressed)
+        self.set_key_image_bytes(key_b, img_a, pressed)
+
     def get_pressed_keys(self) -> list[int]:
         """Return a list of keys that are currently pressed."""
         return [i for i, state in enumerate(self.deck.key_states()) if state]

--- a/test/test.py
+++ b/test/test.py
@@ -302,11 +302,26 @@ def test_key_image_helpers(deck):
         mdeck.set_key_image_bytes(0, img)
         stored = mdeck.get_key_image(0)
         has = mdeck.has_key_image(0)
+        mdeck.copy_key_image(0, 1)
+        copied = mdeck.get_key_image(1)
+        mdeck.move_key_image(1, 2)
+        moved = mdeck.get_key_image(2)
+        moved_from = mdeck.get_key_image(1)
+        img2 = PILHelper.to_native_key_format(deck, PILHelper.create_key_image(deck))
+        mdeck.set_key_image_bytes(3, img2)
+        mdeck.swap_key_images(2, 3)
+        swapped_a = mdeck.get_key_image(2)
+        swapped_b = mdeck.get_key_image(3)
         mdeck.clear_key_image(0)
         deck.close()
 
     assert stored == img
     assert has
+    assert copied == img
+    assert moved == img
+    assert moved_from is None
+    assert swapped_a == img2
+    assert swapped_b == img
     assert mdeck.get_key_image(0) is None
 
 


### PR DESCRIPTION
## Summary
- enhance MacroDeck with `copy_key_image`, `move_key_image`, and `swap_key_images`
- document new helpers in README and CHANGELOG
- test the new key image helper functions

## Testing
- `python test/test.py --test "Key Image Helpers" --model "Stream Deck Original"`

------
https://chatgpt.com/codex/tasks/task_e_687d39e7ca708327831bf0eef98824cf