### PR TITLE
Add MacroDeck reset helper

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 Version 0.9.8:
         - Added macro unregister helpers and key configuration clearing.
 
+Version 0.9.19:
+        - Added ``reset()`` helper to ``MacroDeck`` for clearing all
+          configurations and board state.
+
 Version 0.9.9:
         - Added key query and update helpers for ``MacroDeck`` to simplify key
           management and modification.

--- a/src/StreamDeck/MacroDeck.py
+++ b/src/StreamDeck/MacroDeck.py
@@ -4,7 +4,13 @@
 #   dean [at] fourwalledcubicle [dot] com
 #         www.fourwalledcubicle.com
 #
-"""Simple macro framework for StreamDeck devices."""
+"""Simple macro framework for StreamDeck devices.
+
+This helper class allows applications to associate callbacks with key, dial
+and touch events, manage image and character boards and perform common deck
+operations.  A new :func:`reset` helper is included to clear all stored
+configuration and return the deck to a blank state.
+"""
 
 import subprocess
 import time
@@ -46,6 +52,15 @@ class MacroDeck:
     def is_enabled(self) -> bool:
         """Return ``True`` if macro actions are enabled."""
         return self.enabled
+
+    def reset(self) -> None:
+        """Reset all macros and board state, clearing the deck."""
+
+        self.clear_all_key_configurations()
+        self.board = None
+        self.image_board = None
+        self.enabled = True
+        self.deck.reset()
 
     def register_key_macro(self, key: int, action: Callable[[], Any] | str) -> None:
         """Register a macro action for a key press."""


### PR DESCRIPTION
## Summary
- introduce MacroDeck.reset() to clear macros and board state
- document the new helper and update changelog

## Testing
- `flake8 --config .flake8 src/`
- `bandit --ini .bandit -r src/`
- `mypy --ignore-missing-imports src/` *(fails: Module has no attribute "LANCZOS" and several arg-type/index errors)*
- `python test/test.py`
- `make -C doc html`

------
https://chatgpt.com/codex/tasks/task_e_687d425b3c5883279a3b2d960dd7bd81