### PR TITLE
Add macro existence helpers

### DIFF
--- a/src/StreamDeck/MacroDeck.py
+++ b/src/StreamDeck/MacroDeck.py
@@ -126,6 +126,18 @@ class MacroDeck:
         """Return a list of touchscreen events with registered macros."""
         return list(self.touch_macros.keys())
 
+    def has_key_macro(self, key: int) -> bool:
+        """Return ``True`` if ``key`` has a macro registered."""
+        return key in self.key_macros
+
+    def has_dial_macro(self, dial: int, event: DialEventType) -> bool:
+        """Return ``True`` if ``dial``/``event`` has a macro registered."""
+        return (dial, event) in self.dial_macros
+
+    def has_touch_macro(self, event: TouchscreenEventType) -> bool:
+        """Return ``True`` if ``event`` has a macro registered."""
+        return event in self.touch_macros
+
     def is_key_configured(self, key: int) -> bool:
         """Return ``True`` if the given key has a stored configuration."""
         return key in self.key_configs

--- a/test/test_additional.py
+++ b/test/test_additional.py
@@ -26,22 +26,29 @@ def test_macrodeck_macro_management(deck):
     mdeck.register_key_macro(0, action)
     assert mdeck.get_key_macro(0) is action
     assert mdeck.macro_keys() == [0]
+    assert mdeck.has_key_macro(0)
 
     mdeck.update_key_macro(0, None)
     assert mdeck.get_key_macro(0) is None
+    assert not mdeck.has_key_macro(0)
 
     mdeck.update_key_macro(1, action)
     assert mdeck.get_key_macro(1) is action
+    assert mdeck.has_key_macro(1)
 
     mdeck.register_dial_macro(0, DialEventType.PUSH, action)
     assert mdeck.get_dial_macro(0, DialEventType.PUSH) is action
+    assert mdeck.has_dial_macro(0, DialEventType.PUSH)
     mdeck.update_dial_macro(0, DialEventType.PUSH, None)
     assert mdeck.get_dial_macro(0, DialEventType.PUSH) is None
+    assert not mdeck.has_dial_macro(0, DialEventType.PUSH)
 
     mdeck.register_touch_macro(TouchscreenEventType.SHORT, action)
     assert mdeck.get_touch_macro(TouchscreenEventType.SHORT) is action
+    assert mdeck.has_touch_macro(TouchscreenEventType.SHORT)
     mdeck.update_touch_macro(TouchscreenEventType.SHORT, None)
     assert mdeck.get_touch_macro(TouchscreenEventType.SHORT) is None
+    assert not mdeck.has_touch_macro(TouchscreenEventType.SHORT)
 
 
 def test_macrodeck_copy_move_swap_macros(deck):


### PR DESCRIPTION
## Summary
- add helper methods to check for registered macros
- test the new helper methods

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d4d7b77c88327802a4fade5253a36