### PR TITLE
Add bulk macro helpers

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,10 @@ Version 0.9.20:
         - ``MacroDeck.reset()`` now also clears registered dial and touch
           macros.
 
+Version 0.9.21:
+        - Added bulk dial and touch macro registration and removal helpers.
+        - Added ``clear_all_macros()`` helper to remove all registered macros.
+
 Version 0.9.9:
         - Added key query and update helpers for ``MacroDeck`` to simplify key
           management and modification.

--- a/README.md
+++ b/README.md
@@ -28,10 +28,11 @@ registered macros for keys, dials and touch events.
 Further helpers allow duplicating, moving or swapping key configurations and
 checking if a key already has a configuration. Additional helpers let you copy,
 move or swap just the registered macros and clear all stored key
-configurations in one call. Macro execution can be temporarily disabled and
-re-enabled with ``disable()`` and ``enable()``.
-Bulk helpers can configure or clear several keys at once, register
-multiple macros together and refresh stored images on the device.
+configurations in one call. ``clear_all_macros()`` removes every registered
+macro and macro execution can be temporarily disabled and re-enabled with
+``disable()`` and ``enable()``.
+Bulk helpers can configure or clear several keys at once, register multiple
+key, dial or touch macros together and refresh stored images on the device.
 ``run_loop()`` provides a simple game loop for deck-only games and ``set_key_text()`` displays text directly on a key.
 ``set_key_image_file()`` and ``set_key_image_pil()`` simplify showing images on individual keys. ``set_key_image_bytes()`` accepts pre-formatted images and ``get_key_image()``, ``has_key_image()``, ``clear_key_image()``, ``copy_key_image()``, ``move_key_image()`` and ``swap_key_images()`` help manage stored key images.
 ``display_text()`` draws multi-line text across the deck while ``get_pressed_keys()``

--- a/src/StreamDeck/MacroDeck.py
+++ b/src/StreamDeck/MacroDeck.py
@@ -57,8 +57,7 @@ class MacroDeck:
         """Reset all macros and board state, clearing the deck."""
 
         self.clear_all_key_configurations()
-        self.dial_macros.clear()
-        self.touch_macros.clear()
+        self.clear_all_macros()
         self.board = None
         self.image_board = None
         self.enabled = True
@@ -250,6 +249,42 @@ class MacroDeck:
         """Remove macros for the specified keys."""
         for key in keys:
             self.unregister_key_macro(key)
+
+    def register_dial_macros(
+        self,
+        macros: dict[tuple[int, DialEventType], Callable[[Any], Any] | str],
+    ) -> None:
+        """Register multiple dial macros in one call."""
+        for (dial, event), action in macros.items():
+            self.register_dial_macro(dial, event, action)
+
+    def unregister_dial_macros(
+        self, dial_events: Iterable[tuple[int, DialEventType]]
+    ) -> None:
+        """Remove macros for the specified dial events."""
+        for dial, event in dial_events:
+            self.unregister_dial_macro(dial, event)
+
+    def register_touch_macros(
+        self,
+        macros: dict[TouchscreenEventType, Callable[[Any], Any] | str],
+    ) -> None:
+        """Register multiple touch macros in one call."""
+        for event, action in macros.items():
+            self.register_touch_macro(event, action)
+
+    def unregister_touch_macros(
+        self, events: Iterable[TouchscreenEventType]
+    ) -> None:
+        """Remove macros for the specified touch events."""
+        for event in events:
+            self.unregister_touch_macro(event)
+
+    def clear_all_macros(self) -> None:
+        """Remove all registered key, dial and touch macros."""
+        self.key_macros.clear()
+        self.dial_macros.clear()
+        self.touch_macros.clear()
 
     def configure_keys(self, configs: dict[int, dict[str, Any]]) -> None:
         """Configure several keys in one call."""

--- a/test/test_additional.py
+++ b/test/test_additional.py
@@ -146,3 +146,45 @@ def test_macrodeck_reset(deck):
     assert mdeck.board is None
     assert mdeck.image_board is None
     assert mdeck.is_enabled()
+
+
+def test_macrodeck_bulk_macro_helpers(deck):
+    mdeck = MacroDeck(deck)
+
+    def a(value=None):
+        pass
+
+    def b(value=None):
+        pass
+
+    dial_macros = {
+        (0, DialEventType.PUSH): a,
+        (1, DialEventType.TURN): b,
+    }
+    mdeck.register_dial_macros(dial_macros)
+    assert mdeck.get_dial_macro(0, DialEventType.PUSH) is a
+    assert mdeck.get_dial_macro(1, DialEventType.TURN) is b
+
+    mdeck.unregister_dial_macros([(0, DialEventType.PUSH)])
+    assert mdeck.get_dial_macro(0, DialEventType.PUSH) is None
+    assert mdeck.get_dial_macro(1, DialEventType.TURN) is b
+
+    touch_macros = {
+        TouchscreenEventType.SHORT: a,
+        TouchscreenEventType.LONG: b,
+    }
+    mdeck.register_touch_macros(touch_macros)
+    assert mdeck.get_touch_macro(TouchscreenEventType.SHORT) is a
+    assert mdeck.get_touch_macro(TouchscreenEventType.LONG) is b
+
+    mdeck.unregister_touch_macros([TouchscreenEventType.SHORT])
+    assert mdeck.get_touch_macro(TouchscreenEventType.SHORT) is None
+    assert mdeck.get_touch_macro(TouchscreenEventType.LONG) is b
+
+    mdeck.register_key_macro(0, lambda: None)
+    mdeck.clear_all_macros()
+
+    assert mdeck.key_macros == {}
+    assert mdeck.dial_macros == {}
+    assert mdeck.touch_macros == {}
+


### PR DESCRIPTION
## Summary
- add `clear_all_macros` helper to `MacroDeck`
- add `register_dial_macros`, `unregister_dial_macros`, `register_touch_macros`, `unregister_touch_macros`
- use `clear_all_macros` in `reset`
- document new helpers in README and CHANGELOG
- test new helpers

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882123ce220832796aedc9d153c7b89